### PR TITLE
feature(mask-directive): Add currency and percentage masks

### DIFF
--- a/projects/justa/mask-directive/README.md
+++ b/projects/justa/mask-directive/README.md
@@ -7,22 +7,18 @@ Justa Pagamentos Angular 2+ Directives! A set of NG2 Directives to improve your 
 ## Install
 
 ```bash
-npm install --save @justa/mask-directive
-```
-
-to use the _money mask_ add the [inputmask](https://www.npmjs.com/package/inputmask) dependency.
-
-```bash
 npm install --save @justa/mask-directive inputmask
 ```
 
 ## Usage
 
-Add the `MaskDirectiveModule` in your `app.module.ts` file in the _inports_ array.
+Add the `MaskDirectiveModule` in your `app.module.ts` file in the _imports_ array.
 
 ## Masks
 
-### Money Mask
+### Money Mask (Deprecated)
+
+> *Deprecated*: This directive is deprecated. For Brazilian Real, use the Currency Mask (`jstCurrencyMask`) instead.
 
 Add the `jstMoneyMask` directive to your input.
 
@@ -50,6 +46,45 @@ Add the `jstLegalDocumentMask` Directive to your input.
 
 ```html
 <input jstLegalDocumentMask placeholder="000.000.000-00">
+```
+
+### Currency Mask (Brazil only)
+
+Directive to format currency inputs. The form control value automatically is mutiplied/divided
+by `currencyMultiplier` before rendering/after keyboard input.
+
+#### Props (inputs)
+
+| Prop | type | default |
+|------|------|---------|
+| currencyMultiplier | number | 100 |
+| currencySuffix | string | 'R$ ' | 
+
+**Example**
+
+Add the `jstCurrencyMask` directive to your input:
+
+```html
+<input jstCurrencyMask formControlName="value">
+```
+
+### Percentage mask
+
+Directive to format percentage inputs. The form control value is always between
+0 and 1.
+
+#### Props (inputs)
+
+| Prop | type | default |
+|------|------|---------|
+| percentageSuffix | string | ' %' |
+
+**Example**
+
+Add the `jstPercentageMask` directive to your input:
+
+```html
+<input jstPercentageMask formControlName="value">
 ```
 
 ## License

--- a/projects/justa/mask-directive/package.json
+++ b/projects/justa/mask-directive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justa/mask-directive",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "keywords": [
     "angular-directives",
     "angular",

--- a/projects/justa/mask-directive/src/lib/currency-mask.directive.ts
+++ b/projects/justa/mask-directive/src/lib/currency-mask.directive.ts
@@ -1,0 +1,79 @@
+import {
+  Directive,
+  OnInit,
+  ElementRef,
+  Input,
+  HostListener,
+  Renderer2,
+  OnDestroy,
+  forwardRef,
+} from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import InputMask from 'inputmask';
+
+@Directive({
+  selector: '[jstCurrencyMask]',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => CurrencyMaskDirective),
+      multi: true,
+    },
+  ],
+})
+export class CurrencyMaskDirective implements OnInit, OnDestroy, ControlValueAccessor {
+  @Input() currencyMultiplier = 100;
+  @Input() currencyPrefix = 'R$ ';
+
+  onChange?: (event: any) => void;
+  onTouched?: (event: any) => void;
+
+  private rendererTimeout?: number;
+  private masker?: any;
+
+  constructor(private elementRef: ElementRef, private renderer: Renderer2) {
+    this.masker = new InputMask({
+      alias: 'currency',
+      autoGroup: true,
+      autoUnmask: true,
+      groupSeparator: '.',
+      radixPoint: ',',
+      rightAlign: false,
+      placeholder: '0,00',
+      numericInput: true,
+      prefix: this.currencyPrefix,
+    });
+  }
+
+  ngOnInit() {
+    this.masker.mask(this.elementRef.nativeElement);
+  }
+
+  ngOnDestroy() {
+    window.clearTimeout(this.rendererTimeout);
+  }
+
+  writeValue(rawValue: string): void {
+    const value = parseFloat(rawValue) / this.currencyMultiplier;
+    this.rendererTimeout = window.setTimeout(() => {
+      this.renderer.setProperty(this.elementRef.nativeElement, 'value', value);
+    }, 0);
+  }
+
+  registerOnChange(onChange: (event: any) => void): void {
+    this.onChange = onChange;
+  }
+
+  registerOnTouched(onTouched: (event: any) => void): void {
+    this.onTouched = onTouched;
+  }
+
+  @HostListener('blur', ['$event'])
+  onInputBlur(event: any): void {
+    // Inputmask não troca o separador de casas decimais
+    const value =
+      parseFloat(event.target.value.replace(',', '.')) *
+      this.currencyMultiplier;
+    this.onChange?.(value);
+  }
+}

--- a/projects/justa/mask-directive/src/lib/mask-directive.module.ts
+++ b/projects/justa/mask-directive/src/lib/mask-directive.module.ts
@@ -1,8 +1,16 @@
 import { NgModule } from '@angular/core';
+
 import { MoneyMaskDirective } from './money-mask.directive';
 import { LegalDocumentMaskDirective } from './legal-document-mask.directive';
+import { CurrencyMaskDirective } from './currency-mask.directive';
+import { PercentageMaskDirective } from './percentage-mask.directive';
 
-const MASK_DIRECTIVES = [MoneyMaskDirective, LegalDocumentMaskDirective];
+const MASK_DIRECTIVES = [
+  MoneyMaskDirective,
+  LegalDocumentMaskDirective,
+  CurrencyMaskDirective,
+  PercentageMaskDirective,
+];
 
 @NgModule({
   declarations: [...MASK_DIRECTIVES],

--- a/projects/justa/mask-directive/src/lib/money-mask.directive.ts
+++ b/projects/justa/mask-directive/src/lib/money-mask.directive.ts
@@ -1,6 +1,9 @@
 import { Directive, Input, OnInit, ElementRef, HostListener } from '@angular/core';
 import InputMask from 'inputmask';
 
+/**
+ * @deprecated Use `jstCurrencyMask` instead.
+ */
 @Directive({
   selector: '[jstMoneyMask]',
 })

--- a/projects/justa/mask-directive/src/lib/percentage-mask.directive.ts
+++ b/projects/justa/mask-directive/src/lib/percentage-mask.directive.ts
@@ -1,0 +1,76 @@
+import {
+  Directive,
+  forwardRef,
+  OnInit,
+  OnDestroy,
+  Input,
+  ElementRef,
+  Renderer2,
+  HostListener,
+} from '@angular/core';
+import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
+import InputMask from 'inputmask';
+
+@Directive({
+  selector: '[jstPercentageMask]',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => PercentageMaskDirective),
+      multi: true,
+    },
+  ],
+})
+export class PercentageMaskDirective
+  implements OnInit, OnDestroy, ControlValueAccessor {
+  @Input() percentSuffix = ' %';
+
+  onChange?: (event: any) => void;
+  onTouched?: (event: any) => void;
+
+  private mask: any;
+  private rendererTimeout?: number;
+
+  constructor(private elementRef: ElementRef, private renderer: Renderer2) {
+    this.mask = new InputMask({
+      alias: 'percentage',
+      autoGroup: false,
+      autoUnmask: true,
+      radixPoint: ',',
+      rightAlign: false,
+      placeHolder: '0,00',
+      numericInput: true,
+      digits: 2,
+      suffix: this.percentSuffix,
+    });
+  }
+
+  ngOnInit() {
+    this.mask.mask(this.elementRef.nativeElement);
+  }
+
+  ngOnDestroy() {
+    window.clearTimeout(this.rendererTimeout);
+  }
+
+  writeValue(rawValue: any): void {
+    const value = parseFloat(rawValue) * 100;
+    this.rendererTimeout = window.setTimeout(() => {
+      this.renderer.setProperty(this.elementRef.nativeElement, 'value', value);
+    }, 0);
+  }
+
+  registerOnChange(onChange: (event: any) => void): void {
+    this.onChange = onChange;
+  }
+
+  registerOnTouched(onTouched: (event: any) => void): void {
+    this.onTouched = onTouched;
+  }
+
+  @HostListener('blur', ['$event'])
+  onInputBlur(event: any): void {
+    const value = parseFloat(event.target.value.replace(',', '.')) / 100;
+    this.onChange(value);
+  }
+}


### PR DESCRIPTION
This PR add masks directives for currency (BRL only) and percentage values. It also deprecates `jstMoneyMask` in favor of the new `jstCurrencyMask`. `jstMoneyMask` does not handle currency multipliers, neither implements the `ControlValueAcessor` interface.