### PR TITLE
[Bugfix] Formata campo ao inicializar

### DIFF
--- a/projects/justa/mask-directive/package.json
+++ b/projects/justa/mask-directive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justa/mask-directive",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "keywords": [
     "angular-directives",
     "angular",
@@ -18,6 +18,10 @@
     {
       "name": "Ana Beatriz Ducla",
       "email": "ana.ducla@justa.com.vc"
+    },
+    {
+      "name": "Hugo Branco",
+      "email": "hugo.barbosa@justa.com.vc"
     }
   ],
   "license": "MIT",

--- a/projects/justa/mask-directive/src/lib/legal-document-mask.directive.ts
+++ b/projects/justa/mask-directive/src/lib/legal-document-mask.directive.ts
@@ -1,11 +1,11 @@
-import { Directive, ElementRef, HostListener, Renderer2, OnDestroy } from '@angular/core';
+import { Directive, ElementRef, HostListener, Renderer2, OnDestroy, OnInit } from '@angular/core';
 import { ControlValueAccessor, NgControl } from '@angular/forms';
 import { formatCpf, formatCnpj } from './utils';
 
 @Directive({
   selector: '[jstLegalDocumentMask]',
 })
-export class LegalDocumentMaskDirective implements ControlValueAccessor, OnDestroy {
+export class LegalDocumentMaskDirective implements ControlValueAccessor, OnDestroy, OnInit {
   onChange = (value: any) => {};
   onTouched = () => {};
 
@@ -16,6 +16,14 @@ export class LegalDocumentMaskDirective implements ControlValueAccessor, OnDestr
     private renderer: Renderer2,
     private _control: NgControl,
     ) {}
+
+  ngOnInit(): void {
+    const unformattedValue = this.el.nativeElement.value;
+    if(unformattedValue && unformattedValue.length > 0) {
+      const value = this.returnValue(unformattedValue);
+      this.writeValue(value);
+    }
+  }
 
   ngOnDestroy() {
     clearTimeout(this.writeTimeout);


### PR DESCRIPTION
# Versão mask-directive@1.2.5

## :bug: Bugfix
- **Passa a formatar input caso já inicialize preenchido.**
    - Corrige problema onde o usuário precisava "tocar" no input para que a formatação fosse aplicada; por consequência, também passa a formatar campos que já inicializam preenchidos e desativados.