### PR TITLE
[Bugfix] Formata campo quando valor é alterado sem ação do usuário

### DIFF
--- a/projects/justa/mask-directive/package.json
+++ b/projects/justa/mask-directive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justa/mask-directive",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "keywords": [
     "angular-directives",
     "angular",

--- a/projects/justa/mask-directive/src/lib/legal-document-mask.directive.ts
+++ b/projects/justa/mask-directive/src/lib/legal-document-mask.directive.ts
@@ -78,6 +78,13 @@ export class LegalDocumentMaskDirective implements ControlValueAccessor, OnDestr
     event.target.value = value;
   }
 
+  @HostListener('ngModelChange', ['$event'])
+  ngModelChangeInput(event: any): void {
+    const value = this.returnValue(event);
+    this.writeValue(value);
+  }
+
+
   writeValue(value: any) {
     this.writeTimeout = setTimeout(() => {
       this.renderer.setProperty(this.el.nativeElement, 'value', value);


### PR DESCRIPTION
# Versão mask-directive@1.2.6

## :bug: Bugfix
- **Passa a disparar formatação quando o componente altera o value;**
    - Antes, a formatação só era disparada em eventos disparados pelo usuário (focus, blur, etc).